### PR TITLE
Build instruction with precxx11 abi

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ libtorch (Pre-cxx11 ABI)
 ```
 wget https://download.pytorch.org/libtorch/cu116/libtorch-shared-with-deps-1.12.1%2Bcu116.zip
 unzip libtorch-shared-with-deps-1.12.1+cu116.zip
-export LIBTORCH_PATH=${PWD}
+export LIBTORCH_PATH=${PWD}/libtorch
 ```
 
 pytorch and cudnn

--- a/README.md
+++ b/README.md
@@ -10,24 +10,17 @@ module load cuda/11.4.3 gcc/9.3.0 openmpi/4.0.5 cmake/3.21.3 git/2.30.1
 export CMAKE_CUDA_ARCHITECTURES="7.5;8.0"
 ```
 
-Build PyTorch from master branch: https://github.com/pytorch/pytorch#from-source
+libtorch (Pre-cxx11 ABI)
+```
+wget https://download.pytorch.org/libtorch/cu116/libtorch-shared-with-deps-1.12.1%2Bcu116.zip
+unzip libtorch-shared-with-deps-1.12.1+cu116.zip
+export LIBTORCH_PATH=${PWD}
+```
 
-You could skip this step by using `conda activate /blue/roitberg/apps/cuda114/`
-```bash
-cd /some/path
-git clone --recursive https://github.com/pytorch/pytorch
-cd pytorch
-git submodule sync
-git submodule update --init --recursive --jobs 0
-
-conda create -n lmp python=3.8
-conda activate lmp
-conda install astunparse numpy ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses
-conda install -c pytorch magma-cuda111
-
-export TORCH_CUDA_ARCH_LIST="7.5;8.0"
-export CMAKE_PREFIX_PATH=${CONDA_PREFIX:-"$(dirname $(which conda))/../"}
-python setup.py develop
+pytorch and cudnn
+```
+conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch
+conda install -c conda-forge cudnn=8.3.2
 ```
 
 
@@ -44,11 +37,13 @@ make -j
 # Optionally build with test
 cd ..
 mkdir build-test; cd build-test
-cmake -DPKG_EXTRA-PAIR=on -DPKG_MOLECULE=on -DPKG_OPENMP=on -DENABLE_TESTING=on -DLAMMPS_EXCEPTIONS=on -DLAMMPS_INSTALL_RPATH=yes -DPKG_GPU=no -DGPU_API=cuda -DGPU_ARCH=sm_80 -DPKG_PLUGIN=yes -DCMAKE_INSTALL_PREFIX=${HOME}/.local -DBUILD_MPI=yes -DBUILD_SHARED_LIBS=yes ../cmake/
+# D_GLIBCXX_USE_CXX11_ABI: https://stackoverflow.com/a/50873329/9581569
+cmake -DCMAKE_C_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0'  -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' -DPKG_EXTRA-PAIR=on -DPKG_MOLECULE=on -DPKG_OPENMP=on -DENABLE_TESTING=on -DLAMMPS_EXCEPTIONS=on -DLAMMPS_INSTALL_RPATH=yes -DPKG_GPU=no -DGPU_API=cuda -DGPU_ARCH=sm_80 -DPKG_PLUGIN=yes -DCMAKE_INSTALL_PREFIX=${HOME}/.local -DBUILD_MPI=yes -DBUILD_SHARED_LIBS=yes ../cmake/
+make -j
 # run test
-mpirun -np 1 ctest -V -R lj_smooth
+ctest -V -R lj_smooth
 # could also use the following to test
-mpirun -np 1 ${lammps_root}/build-test/test_pair_style /path/to/mol-pair-lj_smooth.yaml
+${lammps_root}/build-test/test_pair_style ../unittest/force-styles/tests/mol-pair-lj_smooth.yaml
 ```
 
 ## Build lammps-ani
@@ -67,7 +62,7 @@ git clone git@github.com:roitberg-group/lammps-ani.git
 cp torchani_sandbox/torchani/csrc/* lammps-ani/ani_csrc/
 cd lammps-ani
 mkdir build; cd build
-cmake -DLAMMPS_HEADER_DIR=${lammps_root}/src -DCMAKE_PREFIX_PATH="$(python -c 'import torch.utils; print(torch.utils.cmake_prefix_path)')"  ..
+cmake -DCMAKE_C_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0'  -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' -DLAMMPS_HEADER_DIR=${lammps_root}/src -DCMAKE_PREFIX_PATH=${LIBTORCH_PATH} -DCUDNN_INCLUDE_PATH=${CONDA_PREFIX}/include -DCUDNN_LIBRARY_PATH=${CONDA_PREFIX}/lib ..
 make -j
 export LAMMPS_PLUGIN_PATH=${PWD}
 


### PR DESCRIPTION
We have to use  precxx11 abi [GLIBCXX_USE_CXX11_ABI](https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html), because hipergator has very [old GLIBC version](https://github.com/pytorch/pytorch/issues/38765). By using GLIBCXX_USE_CXX11_ABI=0, we could avoid building PyTorch from source and just download [LibTorch](https://pytorch.org/cppdocs/installing.html), this will make life much easier.

TODO:
- [ ] fetching libtorch in CMakefile? [libtorch\_examples/CMakeLists.txt](https://github.com/Maverobot/libtorch_examples/blob/3a28cd396ffb27c42ec3841b46d9867be30a1751/CMakeLists.txt#L10-L23)