### PR TITLE
Export minimal number of models

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         env:
           TEST_WITH_MULTI_PROCS: true
-        run: docker run --gpus all ${{ steps.meta.outputs.tags }} bash -c "nvidia-smi && cd /lammps-ani/tests/ && python save_ani.py && ./test_all.sh && pytest test_lmp_with_ase.py -s -v"
+        run: docker run --gpus all ${{ steps.meta.outputs.tags }} bash -c "nvidia-smi && cd /lammps-ani/tests/ && pytest save_ani.py -s -v && ./test_all.sh && pytest test_lmp_with_ase.py -s -v"
 
       - name: Remove image
         if: ${{ always() }}

--- a/.github/workflows/build_singularity.yml
+++ b/.github/workflows/build_singularity.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build Singularity Image
       run: rm -rf ../lammps-ani.sif && singularity build --nv --fakeroot -B $PWD:/tmp/host_pwd ../lammps-ani.sif Singularity.def
     - name: Test
-      run: singularity exec --cleanenv -H $PWD:/home --pwd /home --nv ../lammps-ani.sif /bin/bash -c "nvidia-smi && cd external/torchani_sandbox && python setup.py install --ext --user && cd ../../ && cd tests/ && python save_ani.py && ./test_all.sh"
+      run: singularity exec --cleanenv -H $PWD:/home --pwd /home --nv ../lammps-ani.sif /bin/bash -c "nvidia-smi && cd external/torchani_sandbox && python setup.py install --ext --user && cd ../../ && cd tests/ && pytest save_ani.py -s -v && ./test_all.sh"
 
 concurrency:
   group: build_singularity-${{ github.event.pull_request.number || github.sha }}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mkdir -p ~/singularity-home
 SINGULARITYENV_CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES singularity exec --cleanenv -H ~/singularity-home:/home --nv lammps-ani_master.sif /bin/bash
 # test
 cd lammps-ani
-nvidia-smi && cd external/torchani_sandbox && python setup.py install --ext --user && cd ../../ && cd tests/ && python save_ani.py && ./test_all.sh
+nvidia-smi && cd external/torchani_sandbox && python setup.py install --ext --user && cd ../../ && cd tests/ && pytest save_ani.py -s -v && ./test_all.sh
 ```
 
 ## Build

--- a/ani_csrc/ani.cpp
+++ b/ani_csrc/ani.cpp
@@ -28,13 +28,15 @@ ANI::ANI(const std::string& model_file, int local_rank, int use_num_models, bool
         "dummy_buffer is not found in your model, please register one with: "
         "self.register_buffer('dummy_buffer', torch.empty(0))");
 
-    // set use_fullnbr
-    TORCH_CHECK(model.hasattr("use_fullnbr"), "use_fullnbr (bool) is not found in your model");
-    model.setattr("use_fullnbr", use_fullnbr);
-
-    // set use_cuaev
-    TORCH_CHECK(model.hasattr("use_cuaev"), "use_cuaev (bool) is not found in your model");
-    model.setattr("use_cuaev", use_cuaev);
+    // TORCH_CHECK(model.hasattr("use_fullnbr"), "use_fullnbr (bool) is not found in your model");
+    // model.setattr("use_fullnbr", use_fullnbr);
+    // TORCH_CHECK(model.hasattr("use_cuaev"), "use_cuaev (bool) is not found in your model");
+    // model.setattr("use_cuaev", use_cuaev);
+    // prepare inputs
+    std::vector<torch::jit::IValue> init_inputs;
+    init_inputs.push_back(use_cuaev);
+    init_inputs.push_back(use_fullnbr);
+    model.get_method("init")(init_inputs);
 
     std::string ani_aev = use_cuaev ? "cuaev" : "pyaev";
     std::string nbrlist = use_fullnbr ? "full" : "half";
@@ -46,10 +48,10 @@ ANI::ANI(const std::string& model_file, int local_rank, int use_num_models, bool
       use_num_models = num_models;
     }
     // prepare inputs
-    std::vector<torch::jit::IValue> inputs;
-    inputs.push_back(use_num_models);
+    std::vector<torch::jit::IValue> select_models_inputs;
+    select_models_inputs.push_back(use_num_models);
     // select models
-    model.get_method("select_models")(inputs);
+    model.get_method("select_models")(select_models_inputs);
 
     // TODO we need to disable nvfuser
     // TORCH_CHECK(model.hasattr("nvfuser_enabled"), "nvfuser_enabled (bool) is not found in your model");

--- a/ani_csrc/ani.h
+++ b/ani_csrc/ani.h
@@ -14,6 +14,7 @@ class ANI {
   torch::Device device;
   torch::Dtype dtype;
   bool use_fullnbr;
+  bool use_cuaev;
 
   torch::Tensor species_t;
   torch::Tensor species_ghost_as_padding_t;
@@ -27,7 +28,7 @@ class ANI {
   torch::Tensor numneigh_t;
 
   ANI() : device(torch::kCPU){};
-  ANI(const std::string& model_file, int local_rank, int use_num_models = -1);
+  ANI(const std::string& model_file, int local_rank, int use_num_models = -1, bool use_cuaev_ = true, bool use_fullnbr_ = true);
 
   // compute with half nbrlist
   void compute(

--- a/ani_csrc/test_model.cpp
+++ b/ani_csrc/test_model.cpp
@@ -20,7 +20,7 @@ int test_cuaev(int argc, const char* argv[]) {
     return -1;
   }
   local_rank = device_str == "cpu" ? -1 : 0;
-  ANI ani{model_file, local_rank};
+  ANI ani{model_file, local_rank, -1, /* use_cuaev_ =*/ false, /* use_fullnbr =*/ false};
 
   torch::Tensor coords = torch::tensor(
       {{{0.03192167, 0.00638559, 0.01301679},
@@ -70,7 +70,7 @@ int test_ani2x_withnbr(int argc, const char* argv[]) {
     return -1;
   }
   local_rank = device_str == "cpu" ? -1 : 0;
-  ANI ani{model_file, local_rank};
+  ANI ani{model_file, local_rank, -1, /* use_cuaev_ =*/ false, /* use_fullnbr =*/ false};
   std::vector<double> coords = {
       2.0110,  -3.1160, 0.4630,  2.8600,  -3.5250, 0.2940,  2.1650,  -2.1810, 0.3310,  2.3860,  -0.1180, 2.2780,  2.8280,
       0.1650,  3.0780,  2.7810,  0.4120,  1.5850,  1.3800,  1.8550,  0.5400,  1.9420,  2.5970,  0.3170,  1.1310,  2.0080,

--- a/build-base.sh
+++ b/build-base.sh
@@ -12,7 +12,7 @@ cd ../../
 
 # save model
 cd tests/
-python save_ani.py
+pytest save_ani.py -s -v
 cd ../
 
 # build kokkos

--- a/pair_ani.cpp
+++ b/pair_ani.cpp
@@ -260,9 +260,36 @@ void PairANI::settings(int narg, char** arg) {
   device_str = arg[2];
   int local_rank = get_local_rank(device_str); // -1 for cpu
   use_num_models = narg > 3 ? utils::inumeric(FLERR, arg[3], false, lmp) : -1; // -1 to use all models
+  bool use_cuaev, use_fullnbr;
+  // cuaev (default) or pyaev
+  if (narg > 4) {
+    std::string aev_str = arg[4];
+    if (aev_str == "cuaev") {
+      use_cuaev = true;
+    } else if (aev_str == "pyaev") {
+      use_cuaev = false;
+    } else {
+      error->all(FLERR, "ani_aev should be cuaev or pyaev");
+    }
+  } else {
+    use_cuaev = true;
+  }
+  // full_nbr (default) or half_nbr
+  if (narg > 5) {
+    std::string nbr_str = arg[5];
+    if (nbr_str == "full") {
+      use_fullnbr = true;
+    } else if (nbr_str == "half") {
+      use_fullnbr = false;
+    } else {
+      error->all(FLERR, "ani_neighbor should be full or half");
+    }
+  } else {
+    use_fullnbr = true;
+  }
 
   // load model
-  ani = ANI(model_file, local_rank, use_num_models);
+  ani = ANI(model_file, local_rank, use_num_models, use_cuaev, use_fullnbr);
 }
 
 /* ----------------------------------------------------------------------

--- a/pair_ani.cpp
+++ b/pair_ani.cpp
@@ -362,6 +362,10 @@ void PairANI::read_restart(FILE* fp) {
   utils::sfread(FLERR, &cutoff, sizeof(double), 1, fp, nullptr, error);
   // use_num_models
   utils::sfread(FLERR, &use_num_models, sizeof(int), 1, fp, nullptr, error);
+  // use_cuaev and use_fullnbr
+  bool use_cuaev, use_fullnbr;
+  utils::sfread(FLERR, &use_cuaev, sizeof(bool), 1, fp, nullptr, error);
+  utils::sfread(FLERR, &use_fullnbr, sizeof(bool), 1, fp, nullptr, error);
 
   // model_file_size device_str_size
   int model_file_size, device_str_size;
@@ -376,7 +380,7 @@ void PairANI::read_restart(FILE* fp) {
 
   // init model
   int local_rank = get_local_rank(device_str);
-  ani = ANI(model_file, local_rank, use_num_models);
+  ani = ANI(model_file, local_rank, use_num_models, use_cuaev, use_fullnbr);
 }
 
 void PairANI::write_restart(FILE* fp) {
@@ -384,6 +388,9 @@ void PairANI::write_restart(FILE* fp) {
   fwrite(&cutoff, sizeof(double), 1, fp);
   // use_num_models
   fwrite(&use_num_models, sizeof(int), 1, fp);
+  // use_cuaev and use_fullnbr
+  fwrite(&ani.use_cuaev, sizeof(bool), 1, fp);
+  fwrite(&ani.use_fullnbr, sizeof(bool), 1, fp);
 
   // TODO fwrite string is a bad practice
   // model_file_size device_str_size

--- a/pair_ani.h
+++ b/pair_ani.h
@@ -46,7 +46,6 @@ class PairANI : public Pair {
   int npairs_max; // if exceed this max number the allocated atom_index12 needs to grow
   std::string model_file;
   std::string device_str;
-  bool use_fullnbr;
   int use_num_models;
   std::vector<double> out_force;
   bool lammps_ani_profiling;

--- a/pair_ani_kokkos.cpp
+++ b/pair_ani_kokkos.cpp
@@ -209,6 +209,9 @@ void PairANIKokkos<DeviceType>::compute(int eflag_in, int vflag_in) {
 
 template <class DeviceType>
 void PairANIKokkos<DeviceType>::init_style() {
+  if (!ani.use_fullnbr)
+    error->all(FLERR, "Pair style ANI requires full neighbor list when using kokkos");
+
   // PairANI::init_style();
   neighbor->add_request(this, NeighConst::REQ_FULL);
 
@@ -217,7 +220,7 @@ void PairANIKokkos<DeviceType>::init_style() {
   request->set_kokkos_host(std::is_same<DeviceType, LMPHostType>::value && !std::is_same<DeviceType, LMPDeviceType>::value);
   request->set_kokkos_device(std::is_same<DeviceType, LMPDeviceType>::value);
   // TODO requires full neighbor list and newton on
-  if (neighflag != FULL || !ani.use_fullnbr)
+  if (neighflag != FULL)
     error->all(FLERR, "Pair style ANI requires full neighbor list when using kokkos");
   if (force->newton_pair == 0)
     error->all(FLERR, "Pair style ANI requires newton pair on when using kokkos");

--- a/tests/in.lammps
+++ b/tests/in.lammps
@@ -4,11 +4,13 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       newton_pair     index  off
-variable       num_models      index  1
 variable       data_file       index  water-0.8nm.data
-variable       model_file      index  ${lammps_ani_root}/tests/ani2x_cuaev_single_full.pt
+variable       ani_model_file  index  ${lammps_ani_root}/tests/ani2x_cuaev_single_full.pt
+variable       ani_device      index  cuda
+variable       ani_num_models  index  1
+variable       ani_aev         index  cuaev
+variable       ani_neighbor    index  full
 variable       dump_file       index  dump.yaml
-variable       device          index  cuda
 variable       change_box      index  'all boundary p p p'
 variable       steps           index  4
 
@@ -25,7 +27,15 @@ newton         ${newton_pair} off
 read_data      ${data_file}
 change_box     ${change_box}
 
-pair_style     ani 5.1 ${model_file} ${device} ${num_models}
+# TODO remove 5.1 cutoff
+# pair_style ani 5.1 model_file device num_models ani_aev ani_neighbor
+# 0. model_file = path to the model file
+# 1. device = cuda/cpu
+# 2. num_models = number of models to use
+# 3. ani_aev = cuaev/pyaev
+# 4. ani_neighbor = full/half
+
+pair_style     ani 5.1 ${ani_model_file} ${ani_device} ${ani_num_models} ${ani_aev} ${ani_neighbor}
 pair_coeff     * *
 
 # timestep (0.1 fs)

--- a/tests/in.lammps
+++ b/tests/in.lammps
@@ -32,8 +32,8 @@ change_box     ${change_box}
 # 0. model_file = path to the model file
 # 1. device = cuda/cpu
 # 2. num_models = number of models to use
-# 3. ani_aev = cuaev/pyaev
-# 4. ani_neighbor = full/half
+# 3. ani_aev = cuaev/pyaev, default as cuaev
+# 4. ani_neighbor = full/half, default as full
 
 pair_style     ani 5.1 ${ani_model_file} ${ani_device} ${ani_num_models} ${ani_aev} ${ani_neighbor}
 pair_coeff     * *

--- a/tests/in.lammps
+++ b/tests/in.lammps
@@ -29,11 +29,11 @@ change_box     ${change_box}
 
 # TODO remove 5.1 cutoff
 # pair_style ani 5.1 model_file device num_models ani_aev ani_neighbor
-# 0. model_file = path to the model file
-# 1. device = cuda/cpu
-# 2. num_models = number of models to use
-# 3. ani_aev = cuaev/pyaev, default as cuaev
-# 4. ani_neighbor = full/half, default as full
+# 0. model_file              = path to the model file
+# 1. device                  = cuda/cpu
+# 2. num_models (Optional)   = number of models to use, default as -1 to use all models
+# 3. ani_aev (Optional)      = cuaev/pyaev, default as cuaev
+# 4. ani_neighbor (Optional) = full/half, default as full
 
 pair_style     ani 5.1 ${ani_model_file} ${ani_device} ${ani_num_models} ${ani_aev} ${ani_neighbor}
 pair_coeff     * *

--- a/tests/test_all.sh
+++ b/tests/test_all.sh
@@ -4,11 +4,11 @@ set -ex
 NUM_GPUs=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
 
 # test_model
-${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_nocuaev_double_half.pt cpu
-${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_nocuaev_single_half.pt cpu
+${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_double.pt cpu
+${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_single.pt cpu
 if [ $NUM_GPUs -gt 0 ]; then
-    ${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_nocuaev_double_half.pt cuda
-    ${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_nocuaev_single_half.pt cuda
+    ${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_double.pt cuda
+    ${LAMMPS_ANI_ROOT}/build/ani_csrc/test_model ani2x_single.pt cuda
 fi
 
 # test_ani2x_nocuaev_double

--- a/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-pbc-single-cuda-newton_bond-on.yaml
+++ b/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-pbc-single-cuda-newton_bond-on.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_cuaev_single_full.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 cuaev full
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-pbc-single-cuda.yaml
+++ b/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-pbc-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_cuaev_single_full.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 cuaev full 
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-single-cuda.yaml
+++ b/tests/test_ani2x_cuaev_single_full/manybody-pair-ani-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_cuaev_single_full.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 cuaev full 
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_cuaev_single_full/run/in.lammps.cuda
+++ b/tests/test_ani2x_cuaev_single_full/run/in.lammps.cuda
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_cuaev_single_full.pt cuda
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_single.pt cuda -1 cuaev full
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_cuaev_single_full_kokkos/run/in.lammps.cuda
+++ b/tests/test_ani2x_cuaev_single_full_kokkos/run/in.lammps.cuda
@@ -18,7 +18,7 @@ newton         ${newton_pair} off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_cuaev_single_full.pt cuda ${num_models}
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_single.pt cuda -1 cuaev full 
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_cuaev_single_half/manybody-pair-ani-pbc-single-cuda.yaml
+++ b/tests/test_ani2x_cuaev_single_half/manybody-pair-ani-pbc-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_cuaev_single_half.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 cuaev half 
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_cuaev_single_half/manybody-pair-ani-single-cuda.yaml
+++ b/tests/test_ani2x_cuaev_single_half/manybody-pair-ani-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_cuaev_single_half.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 cuaev half 
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_cuaev_single_half/run/in.lammps.cuda
+++ b/tests/test_ani2x_cuaev_single_half/run/in.lammps.cuda
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_cuaev_single_half.pt cuda
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_single.pt cuda -1 cuaev half 
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-double-cpu.yaml
+++ b/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-double-cpu.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_double_half.pt cpu
+pair_style: ani 5.1 ../ani2x_double.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-double-cuda.yaml
+++ b/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-double-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_double_half.pt cuda
+pair_style: ani 5.1 ../ani2x_double.pt cuda -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cpu-newton_bond-on.yaml
+++ b/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cpu-newton_bond-on.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_double_half.pt cpu
+pair_style: ani 5.1 ../ani2x_double.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cpu.yaml
+++ b/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cpu.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_double_half.pt cpu
+pair_style: ani 5.1 ../ani2x_double.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cuda.yaml
+++ b/tests/test_ani2x_nocuaev_double_half/manybody-pair-ani-pbc-double-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_double_half.pt cuda
+pair_style: ani 5.1 ../ani2x_double.pt cuda -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_double_half/run/in.lammps.cpu
+++ b/tests/test_ani2x_nocuaev_double_half/run/in.lammps.cpu
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_nocuaev_double_half.pt cpu
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_double.pt cpu -1 pyaev half
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_nocuaev_double_half/run/in.lammps.cuda
+++ b/tests/test_ani2x_nocuaev_double_half/run/in.lammps.cuda
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_nocuaev_double_half.pt cuda
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_double.pt cuda -1 pyaev half
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cpu-newton_bond-on.yaml
+++ b/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cpu-newton_bond-on.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_single_half.pt cpu
+pair_style: ani 5.1 ../ani2x_single.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cpu.yaml
+++ b/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cpu.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_single_half.pt cpu
+pair_style: ani 5.1 ../ani2x_single.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cuda.yaml
+++ b/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-pbc-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_single_half.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-single-cpu.yaml
+++ b/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-single-cpu.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_single_half.pt cpu
+pair_style: ani 5.1 ../ani2x_single.pt cpu -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-single-cuda.yaml
+++ b/tests/test_ani2x_nocuaev_single_half/manybody-pair-ani-single-cuda.yaml
@@ -17,7 +17,7 @@ pre_commands: ! |  # execute before the input template file is read
 post_commands: ! |  # execute right before the actual tests
   newton ${newton_pair} ${newton_bond}  # needs to be here so that restart test works
 input_file: in.ani
-pair_style: ani 5.1 ../ani2x_nocuaev_single_half.pt cuda
+pair_style: ani 5.1 ../ani2x_single.pt cuda -1 pyaev half
 pair_coeff: ! |
   * *
 extract: ! ""

--- a/tests/test_ani2x_nocuaev_single_half/run/in.lammps.cpu
+++ b/tests/test_ani2x_nocuaev_single_half/run/in.lammps.cpu
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_nocuaev_single_half.pt cpu
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_single.pt cpu -1 pyaev half
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_ani2x_nocuaev_single_half/run/in.lammps.cuda
+++ b/tests/test_ani2x_nocuaev_single_half/run/in.lammps.cuda
@@ -16,7 +16,7 @@ newton         off off
 read_data      ../../water-0.8nm.data
 change_box     all boundary p p p
 
-pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_nocuaev_single_half.pt cuda
+pair_style     ani 5.1 ${lammps_ani_root}/tests/ani2x_single.pt cuda -1 pyaev half
 pair_coeff     * *
 
 # Settings: temperature at 300 K, timestep (0.5 fs)

--- a/tests/test_lmp_with_ase.py
+++ b/tests/test_lmp_with_ase.py
@@ -184,13 +184,16 @@ def test_lmp_with_ase(
 
     # prepare configurations
     cuaev_str = "cuaev" if cuaev else "nocuaev"
+    ani_aev_str = "cuaev" if cuaev else "pyaev"
     var_dict = {
         "newton_pair": "off",
-        "num_models": 8,
         "data_file": "water-0.8nm.data",
-        "model_file": f"ani2x_{cuaev_str}_{precision}_{nbr}.pt",
-        "device": device,
-        "change_box": "'all boundary p p p'"
+        "change_box": "'all boundary p p p'",
+        "ani_model_file": f"ani2x_{precision}.pt",
+        "ani_device": device,
+        "ani_num_models": 8,
+        "ani_aev": ani_aev_str,
+        "ani_neighbor": nbr
     }
     if not pbc:
         var_dict["change_box"] = "'all boundary f f f'"


### PR DESCRIPTION
After this change, the users only need to export two model files, `ani2x_single.pt` and `ani2x_double.pt`.
All other parameters will be specified in the lammps pair_style argument:

```
pair_style ani 5.1 model_file device num_models ani_aev ani_neighbor
0. model_file              = path to the model file
1. device                  = cuda/cpu
2. num_models (Optional)   = number of models to use, default as -1 to use all models
3. ani_aev (Optional)      = cuaev/pyaev, default as cuaev
4. ani_neighbor (Optional) = full/half, default as full
```
