### PR TITLE
Add Blackwell (B200) support via LAMMPS/Kokkos upgrade

### DIFF
--- a/build-base.sh
+++ b/build-base.sh
@@ -50,7 +50,7 @@ if [ -f "build-kokkos/install_manifest.txt" ]; then
 fi
 rm -rf build-kokkos; mkdir -p build-kokkos; cd build-kokkos
 # get current gpu architecture by using pytorch to get device capability
-KOKKOS_ARCH=${OVERRIDE_KOKKOS_ARCH:=$(python -c "import torch; gpu_sm = ''.join(map(str, torch.cuda.get_device_capability(0))); gpu_name = torch.cuda.get_device_name(0); kokkos_dict = {'70': 'Kokkos_ARCH_VOLTA70', '75': 'Kokkos_ARCH_TURING75', '80': 'Kokkos_ARCH_AMPERE80', '86': 'Kokkos_ARCH_AMPERE86', '89': 'Kokkos_ARCH_ADA89', '90': 'Kokkos_ARCH_HOPPER90'}; kokkos_arch = kokkos_dict[gpu_sm]; print(kokkos_arch)")}
+KOKKOS_ARCH=${OVERRIDE_KOKKOS_ARCH:=$(python -c "import torch; gpu_sm = ''.join(map(str, torch.cuda.get_device_capability(0))); gpu_name = torch.cuda.get_device_name(0); kokkos_dict = {'70': 'Kokkos_ARCH_VOLTA70', '75': 'Kokkos_ARCH_TURING75', '80': 'Kokkos_ARCH_AMPERE80', '86': 'Kokkos_ARCH_AMPERE86', '89': 'Kokkos_ARCH_ADA89', '90': 'Kokkos_ARCH_HOPPER90', '100': 'Kokkos_ARCH_BLACKWELL100', '120': 'Kokkos_ARCH_BLACKWELL120'}; kokkos_arch = kokkos_dict[gpu_sm]; print(kokkos_arch)")}
 echo Building KOKKOS for ${KOKKOS_ARCH}
 # kokkos does not support compiling for multiple GPU archs
 # -DKokkos_ARCH_TURING75=yes -DKokkos_ARCH_PASCAL60=yes
@@ -59,7 +59,7 @@ cmake -DCMAKE_C_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=${CXX11_ABI}" -DCMAKE_CXX_FLAGS=
 -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/ -DCMAKE_INSTALL_LIBDIR=lib \
 -DBUILD_SHARED_LIBS=yes -DKokkos_ENABLE_CUDA=yes -DKokkos_ENABLE_OPENMP=yes -DKokkos_ENABLE_SERIAL=yes \
 -DKokkos_ARCH_HOSTARCH=yes -DKokkos_ARCH_GPUARCH=on \
--D${KOKKOS_ARCH}=yes -DKokkos_ENABLE_CUDA_LAMBDA=yes \
+-D${KOKKOS_ARCH}=yes \
 ../lib/kokkos
 make -j
 make install

--- a/build-env.sh
+++ b/build-env.sh
@@ -25,3 +25,11 @@ fi
 # Build Options
 export MAKE_J_THREADS=${MAKE_J_THREADS:=""}  # default as all threads
 export OVERRIDE_KOKKOS_ARCH=${OVERRIDE_KOKKOS_ARCH:=""}  # default as null
+
+# Blackwell (SM 100/120) nodes require UCX_NET_DEVICES=mlx5_0:1 to avoid IB crash
+# Auto-detect and set only on Blackwell GPUs; users can still override manually
+_GPU_SM=$(python -c "import torch; print(''.join(map(str, torch.cuda.get_device_capability(0))))" 2>/dev/null || echo "")
+if [[ "$_GPU_SM" == "100" || "$_GPU_SM" == "120" ]]; then
+    export UCX_NET_DEVICES=${UCX_NET_DEVICES:=mlx5_0:1}
+fi
+unset _GPU_SM


### PR DESCRIPTION
- Upgrade external/lammps to stable_22Jul2025_update3 (Kokkos 4.6.2) which introduces Kokkos_ARCH_BLACKWELL100/120 for SM 10.0/12.0 GPUs
- Add SM 100 (B200) and SM 120 to GPU arch auto-detection dict in build-base.sh
- Remove deprecated -DKokkos_ENABLE_CUDA_LAMBDA=yes (always ON in Kokkos 4.x)
- Auto-detect Blackwell nodes in build-env.sh and set UCX_NET_DEVICES=mlx5_0:1 only on SM 100/120 GPUs to fix IB crash; no-op on other GPU types

Tested on HiPerGator B200 node (SM 100):
- model tests: 36 passed / 0 failed (was 24/12; cuaev now works on SM 100)
- water example: non-Kokkos and Kokkos (ani/kk) both run successfully