### PR TITLE
Fix Kokkos pair style to use newton off with manual reverse_comm

### DIFF
--- a/examples/alanine-dipeptide-umbrella/vacuum-new-model/in.lammps
+++ b/examples/alanine-dipeptide-umbrella/vacuum-new-model/in.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 variable       label           index  label 

--- a/examples/alanine-dipeptide-umbrella/vacuum-new-model/run_one.py
+++ b/examples/alanine-dipeptide-umbrella/vacuum-new-model/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/alanine-dipeptide-umbrella/vacuum/in.vacuum.lammps
+++ b/examples/alanine-dipeptide-umbrella/vacuum/in.vacuum.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 variable       label           index  label 

--- a/examples/alanine-dipeptide-umbrella/vacuum/run_one.py
+++ b/examples/alanine-dipeptide-umbrella/vacuum/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/alanine-dipeptide-umbrella/water-new-model/in.lammps
+++ b/examples/alanine-dipeptide-umbrella/water-new-model/in.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 variable       label           index  label 

--- a/examples/alanine-dipeptide-umbrella/water-new-model/run_one.py
+++ b/examples/alanine-dipeptide-umbrella/water-new-model/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/alanine-dipeptide/in.hmr.lammps
+++ b/examples/alanine-dipeptide/in.hmr.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/alanine-dipeptide/in.lammps
+++ b/examples/alanine-dipeptide/in.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/alanine-dipeptide/in.npt.lammps
+++ b/examples/alanine-dipeptide/in.npt.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/alanine-dipeptide/in.shake.lammps
+++ b/examples/alanine-dipeptide/in.shake.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/alanine-dipeptide/in.shake.npt.lammps
+++ b/examples/alanine-dipeptide/in.shake.npt.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/alanine-dipeptide/run.sh
+++ b/examples/alanine-dipeptide/run.sh
@@ -28,7 +28,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_hmr_vacuum.sh
+++ b/examples/alanine-dipeptide/run_hmr_vacuum.sh
@@ -28,7 +28,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_npt.sh
+++ b/examples/alanine-dipeptide/run_npt.sh
@@ -30,7 +30,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_shake.sh
+++ b/examples/alanine-dipeptide/run_shake.sh
@@ -28,7 +28,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_shake_npt.sh
+++ b/examples/alanine-dipeptide/run_shake_npt.sh
@@ -30,7 +30,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_shake_vacuum.sh
+++ b/examples/alanine-dipeptide/run_shake_vacuum.sh
@@ -28,7 +28,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_vacuum.sh
+++ b/examples/alanine-dipeptide/run_vacuum.sh
@@ -28,7 +28,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/alanine-dipeptide/run_vacuum_2.3fs.sh
+++ b/examples/alanine-dipeptide/run_vacuum_2.3fs.sh
@@ -30,7 +30,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in ${LAMMPS_INPUT}
 else
     # run without kokkos

--- a/examples/benchmark/in.lammps
+++ b/examples/benchmark/in.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/benchmark/in.npt.lammps
+++ b/examples/benchmark/in.npt.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/benchmark/in.relax.lammps
+++ b/examples/benchmark/in.relax.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/benchmark/in.stability.lammps
+++ b/examples/benchmark/in.stability.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/benchmark/run_one.py
+++ b/examples/benchmark/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/combustion/in.lammps
+++ b/examples/combustion/in.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/combustion/run_one.py
+++ b/examples/combustion/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/early_earth/in.22M.lammps
+++ b/examples/early_earth/in.22M.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/early_earth/in.big.lammps
+++ b/examples/early_earth/in.big.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/early_earth/in.lammps
+++ b/examples/early_earth/in.lammps
@@ -1,7 +1,7 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
 variable       log_dir         index  logs
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       timestamp       index  timestamp
 # configuration

--- a/examples/early_earth/run_one.py
+++ b/examples/early_earth/run_one.py
@@ -24,7 +24,7 @@ class LammpsRunner:
         """
         Initialize LammpsRunner.
         """
-        var_dict["newton_pair"] = "on" if kokkos else "off"
+        var_dict["newton_pair"] = "off"
         var_dict["ani_device"] = "cuda"
         var_dict["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S.%f")
 

--- a/examples/water-NPT/in.lammps
+++ b/examples/water-NPT/in.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/water-NPT/in.nvt.lammps
+++ b/examples/water-NPT/in.nvt.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/water-NPT/run_lammps.sh
+++ b/examples/water-NPT/run_lammps.sh
@@ -34,7 +34,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in in.lammps
 else
     # run without kokkos

--- a/examples/water-NPT/run_lammps_nvt.sh
+++ b/examples/water-NPT/run_lammps_nvt.sh
@@ -34,7 +34,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}-${RUN_NAME}.log -in in.nvt.lammps
 else
     # run without kokkos

--- a/examples/water/benchmark.sh
+++ b/examples/water/benchmark.sh
@@ -38,7 +38,7 @@ for RUN_KOKKOS in ${KOKKOS_OPTION[@]}; do
                     (set -x;
                     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
                         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-                        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DIR}/water.data \
+                        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DIR}/water.data \
                         -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP} -var timestamp ${TIMESTAMP} \
                         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}.log -in in.lammps
                     )

--- a/examples/water/in.lammps
+++ b/examples/water/in.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/water/in.restart.lammps
+++ b/examples/water/in.restart.lammps
@@ -1,6 +1,6 @@
 # variables
 variable       lammps_ani_root getenv LAMMPS_ANI_ROOT
-# kokkos needs newton_pair on for reverse communication between gpus
+# kokkos needs newton_pair off (LAMMPS Kokkos requires newton off for full neighbor list)
 variable       newton_pair     index  off
 variable       num_models      index  1
 variable       datafile        index  none

--- a/examples/water/run.sh
+++ b/examples/water/run.sh
@@ -25,7 +25,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}.log -in in.lammps
 else
     # run without kokkos

--- a/examples/water/run_restart.sh
+++ b/examples/water/run_restart.sh
@@ -25,7 +25,7 @@ if  [[ $RUN_KOKKOS == "yes" ]]; then
     # LAMMPS_ANI_PROFILING=1 is only for profiling purpose to show the correct timing breakdown
     LAMMPS_ANI_PROFILING=1 mpirun -np ${NUM_GPUS} ${LAMMPS_ROOT}/build/lmp_mpi \
         -k on g ${NUM_GPUS} -sf kk -pk kokkos gpu/aware on \
-        -var newton_pair on -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
+        -var newton_pair off -var num_models ${NUM_MODELS} -var datafile ${DATA_FILE} -var timestamp ${TIMESTAMP} -var modelfile ${MODEL_FILE} -var timestep ${TIMESTEP}\
         -log logs/${TIMESTAMP}-kokkos-models_${NUM_MODELS}-gpus_${NUM_GPUS}.log -in in.restart.lammps
 else
     # run without kokkos

--- a/src/pair_ani_kokkos.cpp
+++ b/src/pair_ani_kokkos.cpp
@@ -15,6 +15,7 @@
 
 #include "atom_kokkos.h"
 #include "atom_masks.h"
+#include "comm.h"
 #include "error.h"
 #include "force.h"
 #include "kokkos.h"
@@ -187,8 +188,16 @@ void PairANIKokkos<DeviceType>::compute(int eflag_in, int vflag_in) {
       eflag_atom,
       vflag);
 
+  // Copy GPU forces to CPU PairANI::out_force, do manual reverse_comm (newton off),
+  // then add corrected forces back — mirrors the non-Kokkos pair_ani.cpp approach.
+  auto out_force_cpu = out_force.contiguous().to(torch::kCPU).to(torch::kDouble).reshape({ntotal * 3});
+  PairANI::out_force.resize(ntotal * 3);
+  std::copy(out_force_cpu.data_ptr<double>(), out_force_cpu.data_ptr<double>() + ntotal * 3, PairANI::out_force.begin());
+  comm->reverse_comm(this);
+  auto corrected = torch::from_blob(PairANI::out_force.data(), {1, ntotal, 3},
+      torch::TensorOptions().dtype(torch::kDouble)).to(tensor_kokkos_force_option);
   torch::Tensor d_force_tensor = torch::from_blob(f.data(), {1, ntotal, 3}, tensor_kokkos_force_option);
-  d_force_tensor += out_force.to(kokkos_device);
+  d_force_tensor += corrected;
 
   if (eflag) {
     eng_vdwl += out_energy.item<double>();
@@ -230,8 +239,8 @@ void PairANIKokkos<DeviceType>::init_style() {
   // TODO requires full neighbor list and newton on
   if (neighflag != FULL)
     error->all(FLERR, "Pair style ANI requires full neighbor list when using kokkos");
-  if (force->newton_pair == 0)
-    error->all(FLERR, "Pair style ANI requires newton pair on when using kokkos");
+  if (force->newton_pair == 1)
+    error->all(FLERR, "Pair style ANI requires newton pair off when using kokkos");
 }
 /* ---------------------------------------------------------------------- */
 

--- a/tests/lammps-unittest/test_ani2x_cuaev_single_full_kokkos/run/run.sh
+++ b/tests/lammps-unittest/test_ani2x_cuaev_single_full_kokkos/run/run.sh
@@ -5,14 +5,14 @@ NUM_GPUs=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
 
 if [ $NUM_GPUs -gt 0 ]; then
     mpirun -np 1 ${LAMMPS_ROOT}/build/lmp_mpi -var num_models 8 -in in.lammps.cuda
-    LAMMPS_ANI_PROFILING=1 mpirun -np 1 ${LAMMPS_ROOT}/build/lmp_mpi -k on g 1 -sf kk -var newton_pair on -var num_models 8 -in in.lammps.cuda
+    LAMMPS_ANI_PROFILING=1 mpirun -np 1 ${LAMMPS_ROOT}/build/lmp_mpi -k on g 1 -sf kk -var newton_pair off -var num_models 8 -in in.lammps.cuda
 fi
 
 # Domain Decomposition with 2 processes
 if [ $NUM_TASKS -gt 1 ]; then
     if [ $NUM_GPUs -gt 0 ]; then
         mpirun -np 2 ${LAMMPS_ROOT}/build/lmp_mpi -var num_models 8 -in in.lammps.cuda
-        LAMMPS_ANI_PROFILING=1 mpirun -np 2 ${LAMMPS_ROOT}/build/lmp_mpi -k on g 2 -sf kk -var newton_pair on -var num_models 8 -in in.lammps.cuda
+        LAMMPS_ANI_PROFILING=1 mpirun -np 2 ${LAMMPS_ROOT}/build/lmp_mpi -k on g 2 -sf kk -var newton_pair off -var num_models 8 -in in.lammps.cuda
     fi
 fi
 

--- a/tests/test_lmp_with_ase.py
+++ b/tests/test_lmp_with_ase.py
@@ -247,7 +247,7 @@ def test_lmp_with_ase(
     if not pbc:
         var_dict["change_box"] = "'all boundary f f f'"
     if kokkos:
-        var_dict["newton_pair"] = "on"
+        var_dict["newton_pair"] = "off"
 
     # run lammps
     lmprunner = LammpsRunner(LAMMPS_PATH, "in.lammps", var_dict, kokkos, num_tasks)


### PR DESCRIPTION
LAMMPS stable_22Jul2025_update3 added commit 27954609b8 which enforces newton off for full neighbor list in Kokkos (via newton_check() called on every newton command). pair_ani_kokkos previously required newton on, creating an irreconcilable conflict.

Fix: mirror the non-Kokkos pair_ani approach — copy out_force GPU tensor to PairANI::out_force CPU vector, call comm->reverse_comm(this) to accumulate ghost atom forces, then add corrected forces back to Kokkos f. Add comm.h include required for comm->reverse_comm call.

Verified on B200 (SM 100): non-Kokkos and Kokkos water examples both run; step-0 energies identical; test_lmp_with_ase Kokkos force errors match non-Kokkos force errors (~6e-4, consistent with float32 precision).